### PR TITLE
allow custom pk names when using "ancestors"

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -5,6 +5,7 @@ from tree_queries.query import TreeQuerySet
 
 
 class Model(TreeNode):
+    custom_id = models.AutoField(primary_key=True)
     position = models.PositiveIntegerField(default=0)
     name = models.CharField(max_length=100)
 

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -387,8 +387,8 @@ class Test(TestCase):
     def test_annotate_tree(self):
         tree = self.create_tree()
         qs = Model.objects.with_tree_fields().filter(
-            Q(id__in=tree.child2.ancestors(include_self=True))
-            | Q(id__in=tree.child2.descendants(include_self=True))
+            Q(pk__in=tree.child2.ancestors(include_self=True))
+            | Q(pk__in=tree.child2.descendants(include_self=True))
         )
         if connections[Model.objects.db].vendor == "postgresql":
             qs = qs.annotate(

--- a/tree_queries/query.py
+++ b/tree_queries/query.py
@@ -80,7 +80,7 @@ class TreeQuerySet(models.QuerySet):
         ids = of.tree_path if include_self else of.tree_path[:-1]
         return (
             self.with_tree_fields()  # TODO tree fields not strictly required
-            .filter(id__in=ids)
+            .filter(pk__in=ids)
             .extra(order_by=["__tree.tree_depth"])
         )
 


### PR DESCRIPTION
I changed **`id__in`** to **`pk__in`** in the filter field for `ancestors`, to allow renaming of the primary key.  