### PR TITLE
Add `order_siblings_by` queryset method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Features and limitations
   primary keys and ``tree_ordering`` an array of values used for
   ordering nodes within their siblings.
 - Besides adding the fields mentioned above the package only adds
-  queryset methods for filtering ancestors and descendants. Other
+  queryset methods for ordering siblings and filtering ancestors and descendants. Other
   features may be useful, but will not be added to the package just
   because it's possible to do so.
 - Little code, and relatively simple when compared to other tree
@@ -56,6 +56,8 @@ Usage
   loops.
 - Call the ``with_tree_fields()`` queryset method if you require the
   additional fields respectively the CTE.
+- Call the ``order_siblings_by('ModelFieldName')`` queryset method if you want to
+  order tree siblings by a specific model field.
 - Create a manager using
   ``TreeQuerySet.as_manager(with_tree_fields=True)`` if you want to add
   tree fields to queries by default.

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -73,3 +73,15 @@ class UUIDModel(TreeNode):
 
     def __str__(self):
         return self.name
+
+
+class MultiOrderedModel(TreeNode):
+    first_position = models.PositiveIntegerField(default=0)
+    second_position = models.PositiveIntegerField(default=0)
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        ordering = ("first_position",)
+
+    def __str__(self):
+        return self.name

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -16,6 +16,7 @@ from .models import (
     StringOrderedModel,
     UnorderedModel,
     UUIDModel,
+    MultiOrderedModel,
 )
 
 
@@ -428,3 +429,40 @@ class Test(TestCase):
             list(child1.ancestors(include_self=True)),
             [root, child1],
         )
+
+    def test_sibling_ordering(self):
+        tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
+
+        tree.root = MultiOrderedModel.objects.create(name="root")
+        tree.child1 = MultiOrderedModel.objects.create(parent=tree.root, first_position=0, second_position=1, name="1")
+        tree.child2 = MultiOrderedModel.objects.create(parent=tree.root, first_position=1, second_position=0, name="2")
+        tree.child1_1 = MultiOrderedModel.objects.create(parent=tree.child1, first_position=0, second_position=1, name="1-1")
+        tree.child2_1 = MultiOrderedModel.objects.create(parent=tree.child2, first_position=0, second_position=1, name="2-1")
+        tree.child2_2 = MultiOrderedModel.objects.create(parent=tree.child2, first_position=1, second_position=0, name="2-2")
+
+        first_order = [
+            tree.root,
+            tree.child1,
+            tree.child1_1,
+            tree.child2,
+            tree.child2_1,
+            tree.child2_2,
+        ]
+
+        second_order = [
+            tree.root,
+            tree.child2,
+            tree.child2_2,
+            tree.child2_1,
+            tree.child1,
+            tree.child1_1,
+        ]
+
+        nodes = MultiOrderedModel.objects.order_siblings_by('second_position')
+        self.assertEqual(list(nodes), second_order)
+
+        nodes = MultiOrderedModel.objects.with_tree_fields()
+        self.assertEqual(list(nodes), first_order)
+
+        nodes = MultiOrderedModel.objects.order_siblings_by('second_position').all()
+        self.assertEqual(list(nodes), second_order)

--- a/tree_queries/query.py
+++ b/tree_queries/query.py
@@ -49,7 +49,22 @@ class TreeQuerySet(models.QuerySet):
 
         Pass ``False`` to revert to a queryset without tree fields.
         """
-        self.query.__class__ = TreeQuery if tree_fields else Query
+        if tree_fields:
+            self.query.__class__ = TreeQuery 
+            self.query._setup_query()
+        else:
+            self.query.__class__ = Query
+        return self
+
+    def order_siblings_by(self, order_by):
+        """
+        Sets TreeQuery sibling_order attribute
+        Pass the name of a single model field as a string
+        to order tree siblings by that model field
+        """
+        self.query.__class__ = TreeQuery
+        self.query._setup_query()
+        self.query.sibling_order = order_by
         return self
 
     @positional(1)


### PR DESCRIPTION
Add an order_siblings_by queryset method to allow the tree sibling ordering to be specified in a queryset.
Add sibling ordering test to the testapp to verify the function of order_siblings_by