### PR TITLE
support querying sub-classes with multi-table inheritance

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -91,3 +91,24 @@ class TreeNodeIsOptional(models.Model):
     parent = models.ForeignKey("self", null=True, on_delete=models.CASCADE)
 
     objects = TreeQuerySet.as_manager()
+
+
+class InheritParentModel(TreeNode):
+    name = models.CharField(max_length=100)
+
+
+class InheritChildModel(InheritParentModel):
+    pass
+
+
+class InheritGrandChildModel(InheritChildModel):
+    pass
+
+
+class InheritAbstractChildModel(InheritParentModel):
+    class Meta:
+        abstract = True
+
+
+class InheritConcreteGrandChildModel(InheritAbstractChildModel):
+    pass


### PR DESCRIPTION
Hey !

Currently, there seem to be a limitation with multi-table inheritance setup when querying subclasses, because the CTE assumes the `parent_id` and `id` columns are on the table of the model (while they are on the super model). I stumbled on this when trying to combine django-tree-queries and django-polymorphic (btw if you're aware of such a combination please let me know).

This fixes the issue by ensuring the CTE is built against the super model.

Two commits in the PR: first with failing tests, second wit actual fix.

