### PR TITLE
quote order_by field in SQL

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -8,11 +8,11 @@ from tree_queries.query import TreeQuerySet
 
 class Model(TreeNode):
     custom_id = models.AutoField(primary_key=True)
-    position = models.PositiveIntegerField(default=0)
+    order = models.PositiveIntegerField(default=0)
     name = models.CharField(max_length=100)
 
     class Meta:
-        ordering = ("position",)
+        ordering = ("order",)
 
     def __str__(self):
         return self.name

--- a/tests/testapp/test_queries.py
+++ b/tests/testapp/test_queries.py
@@ -30,11 +30,11 @@ class Test(TestCase):
     def create_tree(self):
         tree = type("Namespace", (), {})()  # SimpleNamespace for PY2...
         tree.root = Model.objects.create(name="root")
-        tree.child1 = Model.objects.create(parent=tree.root, position=0, name="1")
-        tree.child2 = Model.objects.create(parent=tree.root, position=1, name="2")
-        tree.child1_1 = Model.objects.create(parent=tree.child1, position=0, name="1-1")
-        tree.child2_1 = Model.objects.create(parent=tree.child2, position=0, name="2-1")
-        tree.child2_2 = Model.objects.create(parent=tree.child2, position=1, name="2-2")
+        tree.child1 = Model.objects.create(parent=tree.root, order=0, name="1")
+        tree.child2 = Model.objects.create(parent=tree.root, order=1, name="2")
+        tree.child1_1 = Model.objects.create(parent=tree.child1, order=0, name="1-1")
+        tree.child2_1 = Model.objects.create(parent=tree.child2, order=0, name="2-1")
+        tree.child2_2 = Model.objects.create(parent=tree.child2, order=1, name="2-2")
         return tree
 
     def test_stuff(self):
@@ -141,10 +141,10 @@ class Test(TestCase):
 
     def test_update_aggregate(self):
         self.create_tree()
-        Model.objects.with_tree_fields().update(position=3)
+        Model.objects.with_tree_fields().update(order=3)
         self.assertEqual(
-            Model.objects.with_tree_fields().aggregate(Sum("position")),
-            {"position__sum": 18},
+            Model.objects.with_tree_fields().aggregate(Sum("order")),
+            {"order__sum": 18},
             # TODO Sum("tree_depth") does not work because the field is not
             # known yet.
         )
@@ -267,11 +267,11 @@ class Test(TestCase):
         )
 
     def test_many_ordering(self):
-        root = Model.objects.create(position=1, name="root")
+        root = Model.objects.create(order=1, name="root")
         for i in range(20, 0, -1):
-            Model.objects.create(parent=root, name=f"Node {i}", position=i * 10)
+            Model.objects.create(parent=root, name=f"Node {i}", order=i * 10)
 
-        positions = [m.position for m in Model.objects.with_tree_fields()]
+        positions = [m.order for m in Model.objects.with_tree_fields()]
         self.assertEqual(positions, list(sorted(positions)))
 
     def test_bfs_ordering(self):

--- a/tree_queries/compiler.py
+++ b/tree_queries/compiler.py
@@ -4,7 +4,6 @@ from django.db import connections, models
 from django.db.models.sql.compiler import SQLCompiler
 from django.db.models.sql.query import Query
 
-
 SEPARATOR = "\x1f"
 
 
@@ -279,6 +278,8 @@ class TreeCompiler(SQLCompiler):
                 if _ordered_by_integer(opts, params)
                 else self.CTE_MYSQL_WITH_TEXT_ORDERING
             )
+        if params["order_by"]:
+            params["order_by"] = self.connection.ops.quote_name(params["order_by"])
         sql_0, sql_1 = super().as_sql(*args, **kwargs)
         explain = ""
         if sql_0.startswith("EXPLAIN "):


### PR DESCRIPTION
Fix #51 

This allows using an `ordering` field called `order`. Because `order` is a reserved keyword in SQL, this would cause errors previously.

I first reproduced the issue by changing the order field in the test `Model`. If you'd rather I create a new test model for this, let me know!

I only tested this with postgres locally, so I'm trusting your test suite for other databases. If I can do more to test these, again, please ask :)